### PR TITLE
[Datadog] Fix Static Analysis violation

### DIFF
--- a/src/com/nds/test/SubscriptionValidate.java
+++ b/src/com/nds/test/SubscriptionValidate.java
@@ -3,7 +3,7 @@ package com.nds.test;
 public class SubscriptionValidate {
 
 	public boolean ValSubfields(String sub_id, String cus_id, String pub_id, String desc) {
-		return (sub_id.equals("") || cus_id.equals("") || pub_id.equals("") || desc.equals("") ? true : false);
+		return (sub_id.equals("") || cus_id.equals("") || "".equals(pub_id) || desc.equals("") ? true : false);
 	}
 
 	public boolean Validatesub(String sid) {


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [java-best-practices/literals-first-in-comparison](https://app.datadoghq.com/ci/code-analysis/github.com%2Fsidh11%2Fnds/master/b0f25ffa627af0773adae84a740897e3ac138725/code-quality?staticAnalysisId=AwAAAZbzDPcrxStQuQAAABhBWmJ6RE8yb0FBQlJ5WFRLbnVHekFBQUEAAAAkMDE5NmYzMGQtMjM0Yi00MjhjLWE3YmUtYWI0ZWJhY2I1Njc5AAAHKw)